### PR TITLE
Show more info button for draft projects

### DIFF
--- a/templates/projects/_helpers.html
+++ b/templates/projects/_helpers.html
@@ -256,9 +256,7 @@
                             </p>
                             {% endif %}
                            {% else %}
-                           {% if active_cat != 'draft' %}
                            <p class="readmore"><a href="{{ url_for('project.details', short_name=f.short_name)}}">{{_(readmore_text or 'More info')}}</a></p>
-                           {% endif %}
                            {% endif %}
                        </div>
                    </div>


### PR DESCRIPTION
Closes https://github.com/Scifabric/pybossa/issues/1758

I can't think of any reason not to show the "more info" button for draft projects. If the draft project doesn't belong to the user it won't be returned from the server anyway (?)